### PR TITLE
Include build/bin.js in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage
 yarn.lock
 cache
 build
+!build/bin.js
 dist
 shrinkwrap.yaml
 package-lock.json

--- a/build/bin.js
+++ b/build/bin.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const _1 = __importDefault(require("."));
+const conf_1 = __importDefault(require("conf"));
+const inquirer_1 = __importDefault(require("inquirer"));
+const chalk_1 = __importDefault(require("chalk"));
+const mri_1 = __importDefault(require("mri"));
+const config = new conf_1.default();
+function largestLabelName(labels) {
+    return Math.max(...labels.map(({ name }) => name.length));
+}
+function getSpaces(labelName, minMidth) {
+    const diff = minMidth - labelName.length;
+    return (diff === 0 ? new Array(4) : new Array(diff + 4)).join(' ');
+}
+async function setup(token, reAuth) {
+    if (token && !reAuth) {
+        return token;
+    }
+    const { ghToken } = await inquirer_1.default.prompt([
+        {
+            name: 'ghToken',
+            type: 'password',
+            message: 'Enter Github token',
+            suffix: chalk_1.default.dim(' Required to fetch your repos'),
+            validate(input) {
+                return !!input;
+            },
+        },
+    ]);
+    return ghToken;
+}
+async function handle(octo, force) {
+    const orgs = await octo.listOrgs(force);
+    const { baseRepo, destRepos } = await inquirer_1.default.prompt([
+        {
+            name: 'baseOrg',
+            message: 'Select base github organisation',
+            validate(input) {
+                return !!input;
+            },
+            type: 'list',
+            choices: orgs.map((org) => org.login),
+        },
+        {
+            name: 'baseRepo',
+            message: 'Select base repo',
+            suffix: chalk_1.default.dim(' Used for copying labels'),
+            type: 'list',
+            async choices(answers) {
+                const repos = await octo.listRepos(answers.baseOrg, force);
+                return repos.map((repo) => {
+                    return { name: repo.name, value: repo.full_name };
+                });
+            },
+        },
+        {
+            name: 'destOrg',
+            message: 'Select organisation in which to copy labels',
+            validate(input) {
+                return !!input;
+            },
+            type: 'list',
+            choices: orgs.map((org) => org.login),
+        },
+        {
+            name: 'destRepos',
+            message: 'Select repos in which to copy labels',
+            type: 'checkbox',
+            async choices(answers) {
+                const repos = await octo.listRepos(answers.destOrg, force);
+                return repos.map((repo) => {
+                    return { name: repo.name, value: repo.full_name };
+                });
+            },
+        },
+    ]);
+    const labels = await octo.listLabels(baseRepo, force);
+    const minWidth = largestLabelName(labels);
+    octo.on('repo:start', (repoName) => {
+        console.log('');
+        console.log(chalk_1.default.dim(`Copying to ${repoName} repo`));
+        console.log('=============================================');
+    });
+    octo.on('label:copied', ({ name }) => {
+        console.log('✅', chalk_1.default.dim(name), getSpaces(name, minWidth), chalk_1.default.green('Copied'));
+    });
+    octo.on('label:error', ({ name }, error) => {
+        console.log('❌', chalk_1.default.dim(name), getSpaces(name, minWidth), chalk_1.default.red(error));
+    });
+    await octo.copyLabels(labels, destRepos);
+}
+const args = mri_1.default(process.argv.slice(2));
+setup(config.get('token'), args.reAuth)
+    .then((ghToken) => {
+    config.set('token', ghToken);
+    const octo = new _1.default(ghToken);
+    return handle(octo, args.force);
+})
+    .catch((error) => {
+    console.log(chalk_1.default.red('  Operation failed. Received following response from github'));
+    console.log(chalk_1.default.red(`  ${error.message}`));
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-copy-labels",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Proposed changes

Include `build/bin.js` into version control, so the package can be installed using `npm i -g gh-copy-labels`.

The `package.json` file registers the file properly:

```json
 "bin": {
    "cp-labels": "build/bin.js"
  }
```

But we need to make sure this file is in the packaged release (I checked the zip from v1.1 and it is not included). When I tried to install it I had this error message: 

```bash
npm ERR! code ENOENT
npm ERR! syscall chmod
npm ERR! path /Users/valentinprugnaud/.nvm/versions/node/v12.11.1/lib/node_modules/gh-copy-labels/build/bin.js
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/valentinprugnaud/.nvm/versions/node/v12.11.1/lib/node_modules/gh-copy-labels/build/bin.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/valentinprugnaud/.npm/_logs/2019-12-08T20_43_27_238Z-debug.log
```

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thetutlage/gh-copy-labels/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

N/A
